### PR TITLE
Fixing type for short tags

### DIFF
--- a/Digimarc.NTiff.Test/BasicRead.cs
+++ b/Digimarc.NTiff.Test/BasicRead.cs
@@ -85,7 +85,7 @@ namespace Digimarc.NTiff.Test
                 var ifd0 = tiffStream.ParseIFD(tiffStream.ReadHeader());
 
                 Assert.Equal("NIKON D90", ifd0.tags[7].GetString());
-                Assert.Equal(8, ifd0.tags[3].GetValue<short>(2));
+                Assert.Equal((ushort)8, ifd0.tags[3].GetValue<ushort>(2));
                 Assert.Equal(2991224u, ifd0.tags[22].GetValue<uint>(0));
             }
         }

--- a/Digimarc.NTiff.Test/ExifIO.cs
+++ b/Digimarc.NTiff.Test/ExifIO.cs
@@ -39,7 +39,7 @@ namespace Digimarc.NTiff.Test
 
                 Assert.Equal(36, exif.tags.Length);
                 Assert.Equal(0u, exif.nextIfd);
-                Assert.Equal((short)400, exif.tags.Where(t => t.ID == (ushort)Tags.ExifTags.ISOSpeedRatings).First().GetValue<short>(0));
+                Assert.Equal((ushort)400, exif.tags.Where(t => t.ID == (ushort)Tags.ExifTags.ISOSpeedRatings).First().GetValue<ushort>(0));
             }
         }
     }

--- a/Digimarc.NTiff/TiffStreamReader.cs
+++ b/Digimarc.NTiff/TiffStreamReader.cs
@@ -186,7 +186,7 @@ namespace Digimarc.NTiff
                 case TagDataType.SRational:
                     return ParseTag<SRational>(tag);
                 case TagDataType.Short:
-                    return ParseTag<short>(tag);
+                    return ParseTag<ushort>(tag);
                 case TagDataType.SLong:
                     return ParseTag<int>(tag);
                 case TagDataType.SShort:


### PR DESCRIPTION
SHORT & SSHORT tiff tags are interpreted as equal signed 16-bit value.

Looks like this is a typo.

All tests are successfully passed locally.